### PR TITLE
Set @echo off unless %DEBUG% is set

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,1 +1,2 @@
+@if "%DEBUG%"=="" @echo off
 ./gradlew publishToMavenLocal

--- a/jar.bat
+++ b/jar.bat
@@ -1,1 +1,2 @@
+@if "%DEBUG%"=="" @echo off
 ./gradlew createMojmapPaperclipJar

--- a/patch.bat
+++ b/patch.bat
@@ -1,1 +1,2 @@
+@if "%DEBUG%"=="" @echo off
 ./gradlew applypatches

--- a/rb.bat
+++ b/rb.bat
@@ -1,1 +1,2 @@
+@if "%DEBUG%"=="" @echo off
 ./gradlew rebuildpatches


### PR DESCRIPTION
Uses a system similar to gradlew.bat, so that the commands aren't logged to the console unless %DEBUG% is set