### PR TITLE
Fix enchant command feedback messages

### DIFF
--- a/patches/server/0004-Threaded-Regions.patch
+++ b/patches/server/0004-Threaded-Regions.patch
@@ -12602,10 +12602,10 @@ index 959b82e38f3442a6b19a1f9d7615b6ddab967819..6633e7a3946e06438633a3a6276c6eaa
          }
  
 diff --git a/src/main/java/net/minecraft/server/commands/EnchantCommand.java b/src/main/java/net/minecraft/server/commands/EnchantCommand.java
-index e639c0ec642910e66b1d68ae0b9208ef58d91fce..9ad71bda2f7498ad6e0853a1070c5be2d8016548 100644
+index e639c0ec642910e66b1d68ae0b9208ef58d91fce..ffe400f653706c8bec955611ce898db4ab52f5b2 100644
 --- a/src/main/java/net/minecraft/server/commands/EnchantCommand.java
 +++ b/src/main/java/net/minecraft/server/commands/EnchantCommand.java
-@@ -46,6 +46,12 @@ public class EnchantCommand {
+@@ -46,43 +46,68 @@ public class EnchantCommand {
          })))));
      }
  
@@ -12618,7 +12618,11 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..9ad71bda2f7498ad6e0853a1070c5be2
      private static int enchant(CommandSourceStack source, Collection<? extends Entity> targets, Holder<Enchantment> enchantment, int level) throws CommandSyntaxException {
          Enchantment enchantment2 = enchantment.value();
          if (level > enchantment2.getMaxLevel()) {
-@@ -55,18 +61,26 @@ public class EnchantCommand {
+             throw ERROR_LEVEL_TOO_HIGH.create(level, enchantment2.getMaxLevel());
+         } else {
+-            int i = 0;
++            final java.util.List<java.util.concurrent.CompletableFuture<Boolean>> futures = new java.util.ArrayList<>(); // Folia - region threading
++            final java.util.concurrent.atomic.AtomicReference<Component> possibleSingleDisplayName = new java.util.concurrent.atomic.AtomicReference<>(); // Folia - region threading
  
              for(Entity entity : targets) {
                  if (entity instanceof LivingEntity) {
@@ -12631,6 +12635,8 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..9ad71bda2f7498ad6e0853a1070c5be2
 -                        } else if (targets.size() == 1) {
 -                            throw ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString());
 +                    // Folia start - region threading
++                    final java.util.concurrent.CompletableFuture<Boolean> future = new java.util.concurrent.CompletableFuture<>();
++                    futures.add(future);
 +                    entity.getBukkitEntity().taskScheduler.schedule((LivingEntity nmsEntity) -> {
 +                        try {
 +                            LivingEntity livingEntity = (LivingEntity)nmsEntity;
@@ -12638,24 +12644,58 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..9ad71bda2f7498ad6e0853a1070c5be2
 +                            if (!itemStack.isEmpty()) {
 +                                if (enchantment2.canEnchant(itemStack) && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantments(itemStack).keySet(), enchantment2)) {
 +                                    itemStack.enchant(enchantment2, level);
++                                    possibleSingleDisplayName.set(livingEntity.getDisplayName());
++                                    future.complete(true);
 +                                } else if (targets.size() == 1) {
-+                                    throw ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString());
++                                    future.completeExceptionally(ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString()));
 +                                }
 +                            } else if (targets.size() == 1) {
-+                                throw ERROR_NO_ITEM.create(livingEntity.getName().getString());
++                                future.completeExceptionally(ERROR_NO_ITEM.create(livingEntity.getName().getString()));
 +                            }
-+                        } catch (CommandSyntaxException ex) {
-+                            sendMessage(source, ex);
++                        } finally {
++                            if (!future.isDone()) future.complete(false);
                          }
 -                    } else if (targets.size() == 1) {
 -                        throw ERROR_NO_ITEM.create(livingEntity.getName().getString());
 -                    }
-+                    }, null, 1L);
-+                    ++i;
++                    }, ignored -> future.complete(false), 1L);
 +                    // Folia end - region threading
                  } else if (targets.size() == 1) {
                      throw ERROR_NOT_LIVING_ENTITY.create(entity.getName().getString());
                  }
+             }
+-
+-            if (i == 0) {
+-                throw ERROR_NOTHING_HAPPENED.create();
+-            } else {
+-                if (targets.size() == 1) {
+-                    source.sendSuccess(Component.translatable("commands.enchant.success.single", enchantment2.getFullname(level), targets.iterator().next().getDisplayName()), true);
++            // Folia start - region threading
++            java.util.concurrent.CompletableFuture.allOf(futures.toArray(java.util.concurrent.CompletableFuture[]::new)).whenCompleteAsync((ignored, exception) -> {
++                if (exception != null) {
++                    if (exception instanceof final java.util.concurrent.CompletionException ce && ce.getCause() instanceof final CommandSyntaxException cse) sendMessage(source, cse);
++                    return;
++                }
++                final long i = futures.stream().filter(java.util.concurrent.CompletableFuture::join).count();
++                if (i == 0) {
++                    sendMessage(source, ERROR_NOTHING_HAPPENED.create());
+                 } else {
+-                    source.sendSuccess(Component.translatable("commands.enchant.success.multiple", enchantment2.getFullname(level), targets.size()), true);
++                    if (i == 1) {
++                        source.sendSuccess(Component.translatable("commands.enchant.success.single", enchantment2.getFullname(level), possibleSingleDisplayName.get()), true);
++                    } else {
++                        source.sendSuccess(Component.translatable("commands.enchant.success.multiple", enchantment2.getFullname(level), i), true);
++                    }
+                 }
+-
+-                return i;
+-            }
++            });
++            return futures.size();
++            // Folia end - region threading
+         }
+     }
+ }
 diff --git a/src/main/java/net/minecraft/server/commands/ExperienceCommand.java b/src/main/java/net/minecraft/server/commands/ExperienceCommand.java
 index a628e3730b1c26c2e6a85c449440af0afe4c0d8d..6651376603c3fb2331ae0955343285ac7c37726f 100644
 --- a/src/main/java/net/minecraft/server/commands/ExperienceCommand.java

--- a/patches/server/0004-Threaded-Regions.patch
+++ b/patches/server/0004-Threaded-Regions.patch
@@ -12602,10 +12602,10 @@ index 959b82e38f3442a6b19a1f9d7615b6ddab967819..6633e7a3946e06438633a3a6276c6eaa
          }
  
 diff --git a/src/main/java/net/minecraft/server/commands/EnchantCommand.java b/src/main/java/net/minecraft/server/commands/EnchantCommand.java
-index e639c0ec642910e66b1d68ae0b9208ef58d91fce..ffe400f653706c8bec955611ce898db4ab52f5b2 100644
+index e639c0ec642910e66b1d68ae0b9208ef58d91fce..abe7463f1e87449d65870955e58f257d4b8168c1 100644
 --- a/src/main/java/net/minecraft/server/commands/EnchantCommand.java
 +++ b/src/main/java/net/minecraft/server/commands/EnchantCommand.java
-@@ -46,43 +46,68 @@ public class EnchantCommand {
+@@ -46,43 +46,69 @@ public class EnchantCommand {
          })))));
      }
  
@@ -12621,7 +12621,8 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..ffe400f653706c8bec955611ce898db4
              throw ERROR_LEVEL_TOO_HIGH.create(level, enchantment2.getMaxLevel());
          } else {
 -            int i = 0;
-+            final java.util.List<java.util.concurrent.CompletableFuture<Boolean>> futures = new java.util.ArrayList<>(); // Folia - region threading
++            final java.util.concurrent.atomic.AtomicInteger changed = new java.util.concurrent.atomic.AtomicInteger(0); // Folia - region threading
++            final java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(targets.size()); // Folia - region threading
 +            final java.util.concurrent.atomic.AtomicReference<Component> possibleSingleDisplayName = new java.util.concurrent.atomic.AtomicReference<>(); // Folia - region threading
  
              for(Entity entity : targets) {
@@ -12635,8 +12636,6 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..ffe400f653706c8bec955611ce898db4
 -                        } else if (targets.size() == 1) {
 -                            throw ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString());
 +                    // Folia start - region threading
-+                    final java.util.concurrent.CompletableFuture<Boolean> future = new java.util.concurrent.CompletableFuture<>();
-+                    futures.add(future);
 +                    entity.getBukkitEntity().taskScheduler.schedule((LivingEntity nmsEntity) -> {
 +                        try {
 +                            LivingEntity livingEntity = (LivingEntity)nmsEntity;
@@ -12645,56 +12644,55 @@ index e639c0ec642910e66b1d68ae0b9208ef58d91fce..ffe400f653706c8bec955611ce898db4
 +                                if (enchantment2.canEnchant(itemStack) && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantments(itemStack).keySet(), enchantment2)) {
 +                                    itemStack.enchant(enchantment2, level);
 +                                    possibleSingleDisplayName.set(livingEntity.getDisplayName());
-+                                    future.complete(true);
++                                    changed.incrementAndGet();
 +                                } else if (targets.size() == 1) {
-+                                    future.completeExceptionally(ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString()));
++                                    throw ERROR_INCOMPATIBLE.create(itemStack.getItem().getName(itemStack).getString());
 +                                }
 +                            } else if (targets.size() == 1) {
-+                                future.completeExceptionally(ERROR_NO_ITEM.create(livingEntity.getName().getString()));
++                                throw ERROR_NO_ITEM.create(livingEntity.getName().getString());
 +                            }
-+                        } finally {
-+                            if (!future.isDone()) future.complete(false);
++                        } catch (final CommandSyntaxException exception) {
++                            sendMessage(source, exception);
++                            return; // don't send feedback twice
                          }
 -                    } else if (targets.size() == 1) {
 -                        throw ERROR_NO_ITEM.create(livingEntity.getName().getString());
 -                    }
-+                    }, ignored -> future.complete(false), 1L);
-+                    // Folia end - region threading
++                        sendFeedback(source, enchantment2, level, possibleSingleDisplayName, count, changed);
++                    }, ignored -> sendFeedback(source, enchantment2, level, possibleSingleDisplayName, count, changed), 1L);
                  } else if (targets.size() == 1) {
                      throw ERROR_NOT_LIVING_ENTITY.create(entity.getName().getString());
++                } else {
++                    sendFeedback(source, enchantment2, level, possibleSingleDisplayName, count, changed);
++                    // Folia end - region threading
                  }
              }
 -
--            if (i == 0) {
++            return targets.size(); // Folia - region threading
++        }
++    }
++    // Folia start - region threading
++    private static void sendFeedback(final CommandSourceStack source, final Enchantment enchantment2, final int level, final java.util.concurrent.atomic.AtomicReference<Component> possibleSingleDisplayName, final java.util.concurrent.atomic.AtomicInteger count, final java.util.concurrent.atomic.AtomicInteger changed) {
++        if (count.decrementAndGet() == 0) {
++            final int i = changed.get();
+             if (i == 0) {
 -                throw ERROR_NOTHING_HAPPENED.create();
--            } else {
++                sendMessage(source, ERROR_NOTHING_HAPPENED.create());
+             } else {
 -                if (targets.size() == 1) {
 -                    source.sendSuccess(Component.translatable("commands.enchant.success.single", enchantment2.getFullname(level), targets.iterator().next().getDisplayName()), true);
-+            // Folia start - region threading
-+            java.util.concurrent.CompletableFuture.allOf(futures.toArray(java.util.concurrent.CompletableFuture[]::new)).whenCompleteAsync((ignored, exception) -> {
-+                if (exception != null) {
-+                    if (exception instanceof final java.util.concurrent.CompletionException ce && ce.getCause() instanceof final CommandSyntaxException cse) sendMessage(source, cse);
-+                    return;
-+                }
-+                final long i = futures.stream().filter(java.util.concurrent.CompletableFuture::join).count();
-+                if (i == 0) {
-+                    sendMessage(source, ERROR_NOTHING_HAPPENED.create());
++                if (i == 1) {
++                    source.sendSuccess(Component.translatable("commands.enchant.success.single", enchantment2.getFullname(level), possibleSingleDisplayName.get()), true);
                  } else {
 -                    source.sendSuccess(Component.translatable("commands.enchant.success.multiple", enchantment2.getFullname(level), targets.size()), true);
-+                    if (i == 1) {
-+                        source.sendSuccess(Component.translatable("commands.enchant.success.single", enchantment2.getFullname(level), possibleSingleDisplayName.get()), true);
-+                    } else {
-+                        source.sendSuccess(Component.translatable("commands.enchant.success.multiple", enchantment2.getFullname(level), i), true);
-+                    }
++                    source.sendSuccess(Component.translatable("commands.enchant.success.multiple", enchantment2.getFullname(level), i), true);
                  }
 -
 -                return i;
--            }
-+            });
-+            return futures.size();
-+            // Folia end - region threading
+             }
          }
      }
++    // Folia end - region threading
  }
 diff --git a/src/main/java/net/minecraft/server/commands/ExperienceCommand.java b/src/main/java/net/minecraft/server/commands/ExperienceCommand.java
 index a628e3730b1c26c2e6a85c449440af0afe4c0d8d..6651376603c3fb2331ae0955343285ac7c37726f 100644


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Folia/issues/12

This issue probably exists in other places where "feedback messages" are sent in commands, but I just wanted to see if this was an acceptable solution to the issue. 

Amaranth also suggested you could keep some atomic int counters that incremented/decremented appropriately so in the last of the scheduled entity tasks, the messages could be sent there so that's an alternative solution.