### PR TITLE
Fix possible async addEffect call on raid completion

### DIFF
--- a/patches/server/0032-Fix-off-region-raid-heroes.patch
+++ b/patches/server/0032-Fix-off-region-raid-heroes.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: WillQi <williamqipizza@gmail.com>
+Date: Mon, 15 May 2023 23:45:09 -0600
+Subject: [PATCH] Fix off region raid heroes
+
+This patch aims to solve a potential incorrect thread call when completing a raid.
+If a player is a hero of the village but proceeds to leave the region of the
+raid before it's completion, it would throw an exception due to not being on the
+same region thread anymore.
+
+diff --git a/src/main/java/net/minecraft/world/entity/raid/Raid.java b/src/main/java/net/minecraft/world/entity/raid/Raid.java
+index 359f1690497eac00899eb26c17308e0a6fe943ad..66af0e067abdcea8b4116c23c6adb45aeeec0273 100644
+--- a/src/main/java/net/minecraft/world/entity/raid/Raid.java
++++ b/src/main/java/net/minecraft/world/entity/raid/Raid.java
+@@ -407,12 +407,25 @@ public class Raid {
+                             if (entity instanceof LivingEntity && !entity.isSpectator()) {
+                                 LivingEntity entityliving = (LivingEntity) entity;
+ 
+-                                entityliving.addEffect(new MobEffectInstance(MobEffects.HERO_OF_THE_VILLAGE, 48000, this.badOmenLevel - 1, false, false, true));
++                                // Folia start - Fix off region raid heroes
++                                entityliving.getBukkitLivingEntity().taskScheduler.schedule(task -> {
++                                    entityliving.addEffect(new MobEffectInstance(MobEffects.HERO_OF_THE_VILLAGE, 48000, this.badOmenLevel - 1, false, false, true));
++
++                                    if (entityliving instanceof ServerPlayer) {
++                                        ServerPlayer entityplayer = (ServerPlayer) entityliving;
++
++                                        entityplayer.awardStat(Stats.RAID_WIN);
++                                        CriteriaTriggers.RAID_WIN.trigger(entityplayer);
++                                    }
++                                }, null, 0);
++                                // Folia end
+                                 if (entityliving instanceof ServerPlayer) {
+                                     ServerPlayer entityplayer = (ServerPlayer) entityliving;
+ 
+-                                    entityplayer.awardStat(Stats.RAID_WIN);
+-                                    CriteriaTriggers.RAID_WIN.trigger(entityplayer);
++                                    // Folia start - Fix off region raid heroes
++                                    // entityplayer.awardStat(Stats.RAID_WIN);
++                                    // CriteriaTriggers.RAID_WIN.trigger(entityplayer);
++                                    // Folia end
+                                     winners.add(entityplayer.getBukkitEntity()); // CraftBukkit
+                                 }
+                             }


### PR DESCRIPTION
This pull request aims to solve a potential async call when completing a raid.
From my understanding, if a player is a hero of the village but proceeds to leave the region of the raid before it's completion, it would throw the async addEffect exception.

This pull request aims to resolve this by ensuring that the relevant code is executed on the entity's scheduler and solve #65 