### PR TITLE
Add asyncTeleport events

### DIFF
--- a/patches/server/0023-Add-asyncTeleport-events.patch
+++ b/patches/server/0023-Add-asyncTeleport-events.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: WillQi <williamqipizza@gmail.com>
+Date: Sun, 1 May 2023 20:22:30 -0600
+Subject: [PATCH] Add asyncTeleport events
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 08e61a8940c142c68ed93359084ea46c7fd52310..7dc8fb545e8bccfdb661c3a86dfef522bc20421d 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -125,6 +125,7 @@ import net.minecraft.world.phys.shapes.Shapes;
+ import net.minecraft.world.phys.shapes.VoxelShape;
+ import net.minecraft.world.scores.PlayerTeam;
+ import net.minecraft.world.scores.Team;
++import org.bukkit.event.entity.*;
+ import org.slf4j.Logger;
+ import org.bukkit.Bukkit;
+ import org.bukkit.Location;
+@@ -135,7 +136,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
+ import org.bukkit.entity.Hanging;
+ import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Vehicle;
+-import org.bukkit.event.entity.EntityCombustByEntityEvent;
+ import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+ import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
+ import org.bukkit.event.vehicle.VehicleEnterEvent;
+@@ -145,11 +145,6 @@ import org.bukkit.craftbukkit.entity.CraftEntity;
+ import org.bukkit.craftbukkit.entity.CraftPlayer;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.entity.Pose;
+-import org.bukkit.event.entity.EntityAirChangeEvent;
+-import org.bukkit.event.entity.EntityCombustEvent;
+-import org.bukkit.event.entity.EntityDropItemEvent;
+-import org.bukkit.event.entity.EntityPortalEvent;
+-import org.bukkit.event.entity.EntityPoseChangeEvent;
+ import org.bukkit.event.player.PlayerTeleportEvent;
+ import org.bukkit.plugin.PluginManager;
+ // CraftBukkit end
+@@ -3741,16 +3736,46 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+             }
+         }
+ 
+-        // TODO any events that can modify go HERE
++
++        // Call teleport event
++        Location targetLocation = new Location(destination.getWorld(), pos.x, pos.y, pos.z);
++        if (yaw != null) {
++            targetLocation.setYaw(yaw);
++        }
++        if (pitch != null) {
++            targetLocation.setPitch(pitch);
++        }
++
++        if (bukkitEntity instanceof org.bukkit.entity.Player) {
++            org.bukkit.entity.Player player = (org.bukkit.entity.Player) bukkitEntity;
++            PlayerTeleportEvent teleportEvent = new PlayerTeleportEvent(player, bukkitEntity.getLocation(), targetLocation, cause);
++            level.getCraftServer().getPluginManager().callEvent(teleportEvent);
++
++            if (teleportEvent.isCancelled()) {
++                return false;
++            }
++            targetLocation = teleportEvent.getTo();
++        } else {
++            EntityTeleportEvent teleportEvent = new EntityTeleportEvent(bukkitEntity, bukkitEntity.getLocation(), targetLocation);
++            level.getCraftServer().getPluginManager().callEvent(teleportEvent);
++
++            if (teleportEvent.isCancelled()) {
++                return false;
++            }
++            targetLocation = teleportEvent.getTo();
++        }
++
+ 
+         // check for same region
+-        if (destination == this.getLevel()) {
++        CraftWorld targetWorld = (CraftWorld) targetLocation.getWorld();
++        Vec3 targetPosition = new Vec3(targetLocation.getX(), targetLocation.getY(), targetLocation.getZ());
++        if (targetWorld.getHandle() == this.getLevel()) {
+             Vec3 currPos = this.position();
+             if (
+                 destination.regioniser.getRegionAtUnsynchronised(
+                     io.papermc.paper.util.CoordinateUtils.getChunkX(currPos), io.papermc.paper.util.CoordinateUtils.getChunkZ(currPos)
+                 ) == destination.regioniser.getRegionAtUnsynchronised(
+-                    io.papermc.paper.util.CoordinateUtils.getChunkX(pos), io.papermc.paper.util.CoordinateUtils.getChunkZ(pos)
++                    io.papermc.paper.util.CoordinateUtils.getChunkX(targetPosition), io.papermc.paper.util.CoordinateUtils.getChunkZ(targetPosition)
+                 )
+             ) {
+                 EntityTreeNode passengerTree = this.detachPassengers();


### PR DESCRIPTION
Figured out what was wrong with my previous pull request #67  due to a misunderstanding of internal paper methods regarding the chunk coordinate calculations.  This pull request fixes what it had problems with.

Currently, teleports caused by methods such as ender pearls or the `/tp` command do not trigger `PlayerTeleportEvent` or the `EntityTeleportEvent`. 

This pull request implements the events when `teleportAsync` is called.
