### PR TITLE
Fix off thread spider addEffect

### DIFF
--- a/patches/server/0024-Prevent-off-thread-spider-addEffect.patch
+++ b/patches/server/0024-Prevent-off-thread-spider-addEffect.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Sofiane H. Djerbi" <46628754+kugge@users.noreply.github.com>
+Date: Thu, 29 Jun 2023 21:52:44 +0300
+Subject: [PATCH] Prevent off thread spider addEffect
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Spider.java b/src/main/java/net/minecraft/world/entity/monster/Spider.java
+index 05432184077752b1d0cb764a5e39ed875748b2d6..7655ce310cbda6cb577ed0c4fe1125e347a562ef 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Spider.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Spider.java
+@@ -180,7 +180,9 @@ public class Spider extends Monster {
+             MobEffect mobeffectlist = entityspider_groupdataspider.effect;
+ 
+             if (mobeffectlist != null) {
++                this.getBukkitEntity().taskScheduler.schedule(task -> { // Folia - Prevent off thread spider addEffect
+                 this.addEffect(new MobEffectInstance(mobeffectlist, -1), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.SPIDER_SPAWN); // CraftBukkit
++                }, null, 1); // Folia - Prevent off thread spider addEffect
+             }
+         }
+ 


### PR DESCRIPTION
Spawning structures that contains spiders can cause crash if mobeffectlist != null