### PR TITLE
Upload built version of Folia from GitHub CI to artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,7 @@ jobs:
         run: ./gradlew applyPatches
       - name: Build
         run: ./gradlew build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Folia
+          path: build/libs


### PR DESCRIPTION
This should potentially prevent cases, where people, who don't know how to compile something, ask other people to do it and get a virus instead of the real version of Folia.

There is no need to change anything in docs, although it would be better for everyone, if you will set up build downloading same how it does Paper. But for now, it is just a shortcut and easier way to get this awesome core.