### PR TITLE
Freeze Ubuntu, Do not persist credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
   build:
     # Only run on PRs if the source branch is on someone else's repo
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        with:
+          persist-credentials: false
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK


### PR DESCRIPTION
[This](https://github.com/PaperMC/Folia/pull/304) except 1 and 2 are already in master, 4th change isn't and Ubuntu will be frozen to 22.04 for stability reasons.