### PR TITLE
Auto Release Jar for Folia.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,24 +7,38 @@ on:
 
 jobs:
   build:
-    # Only run on PRs if the source branch is on someone else's repo
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
+
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
+
       - name: Configure Git User Details
         run: git config --global user.email "actions@github.com" && git config --global user.name "Github Actions"
+
       - name: Apply Patches
         run: ./gradlew applyPatches
+
       - name: Build
         run: ./gradlew build
+
+      - name: Jar
+        run: ./gradlew createMojmapPaperclipJar
+
+      - name: Upload Jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-jar
+          path: build/libs/*.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Patch and Build
 on:
   push:
     branches: [ "**" ]
-  pull_request:
 
 jobs:
   build:
@@ -37,8 +36,12 @@ jobs:
       - name: Jar
         run: ./gradlew createMojmapPaperclipJar
 
-      - name: Upload Jar to Github
-        uses: actions/upload-artifact@v4
+      - name: Upload JAR to GitHub Releases
+        uses: softprops/action-gh-release@v2
         with:
-          name: built-jar
-          path: build/libs/*.jar
+          tag_name: latest
+          files: build/libs/*.jar
+          prerelease: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Jar
         run: ./gradlew createMojmapPaperclipJar
 
-      - name: Upload Jar
+      - name: Upload Jar to Github
         uses: actions/upload-artifact@v4
         with:
           name: built-jar


### PR DESCRIPTION
I know that paper releases are only published on the papermc site, but I think this may be an exception for folia, for now I'm in favor of releasing it on github, at least until the stable version is released.