### PR TITLE
Refactor entity name retrieval to use `this.entity` for off-owning-thread access

### DIFF
--- a/folia-server/paper-patches/features/0008-Refactor-entity-name-retrieval-to-use-this.entity-fo.patch
+++ b/folia-server/paper-patches/features/0008-Refactor-entity-name-retrieval-to-use-this.entity-fo.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: david <github@nonswag.dev>
+Date: Sun, 29 Jun 2025 16:55:34 +0200
+Subject: [PATCH] Refactor entity name retrieval to use `this.entity` for
+ off-owning-thread access
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 852e1ffef6a022caad7c8eff34091e50112a2290..2afa9b88f1c4dfb7c11b66160985919093a8d15b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -795,17 +795,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+ 
+     @Override
+     public String getName() {
+-        return CraftChatMessage.fromComponent(this.getHandle().getName());
++        return CraftChatMessage.fromComponent(this.entity.getName());
+     }
+ 
+     @Override
+     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component name() {
+-        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.getHandle().getName());
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.entity.getName());
+     }
+ 
+     @Override
+     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component teamDisplayName() {
+-        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.getHandle().getDisplayName());
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.entity.getDisplayName());
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index b6b95157ab3a09dddb86f85eb8b5851b7ffe46d3..96788895e7802dcac0b6a0b69994c10ddbccae0d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -246,7 +246,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+ 
+     @Override
+     public String getName() {
+-        return this.getHandle().getScoreboardName();
++        return this.entity.getScoreboardName();
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
+index 19dbe0ff207b0647185bb5650a614b25bc9f133e..dbcc5c7b0ee5dd18daac978238cfaeb8550c7689 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
+@@ -53,12 +53,12 @@ public class CraftMinecartCommand extends CraftMinecart implements CommandMineca
+ 
+     @Override
+     public String getName() {
+-        return CraftChatMessage.fromComponent(this.getHandle().getCommandBlock().getName());
++        return CraftChatMessage.fromComponent(((MinecartCommandBlock) this.entity).getCommandBlock().getName());
+     }
+ 
+     @Override
+     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component name() {
+-        return io.papermc.paper.adventure.PaperAdventure.asAdventure(this.getHandle().getCommandBlock().getName());
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(((MinecartCommandBlock) this.entity).getCommandBlock().getName());
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 8abe9c8db30e4a2d60cad87a4fc4bd1157faa2c1..e322aef6ac6dd599e5e8ae255684e2c854c715ff 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -3070,7 +3070,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     // Paper start
+     @Override
+     public net.kyori.adventure.text.Component displayName() {
+-        return this.getHandle().adventure$displayName;
++        return ((ServerPlayer) this.entity).adventure$displayName;
+     }
+ 
+     @Override


### PR DESCRIPTION
This allows to get an entity's (team) name without having to switch thread context