### PR TITLE
Fix crafting slots not dropping on death and are instead kept

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -16871,6 +16871,19 @@ index 3c961b76769f16160caedce8ec32bb2a2561163f..c24cd09ec2e2a98ed5d904772ebcb027
      }
      // Paper end
  
+diff --git a/net/minecraft/world/inventory/AbstractContainerMenu.java b/net/minecraft/world/inventory/AbstractContainerMenu.java
+index c533045b6185930fbfe2b98530153453b6e769ee..8614ec6aea2ea56608af8962736095b9c08f0e43 100644
+--- a/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -713,7 +713,7 @@ public abstract class AbstractContainerMenu {
+     }
+ 
+     private static void dropOrPlaceInInventory(Player player, ItemStack stack) {
+-        boolean flag = player.isRemoved() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION;
++        boolean flag = !player.isAlive() && player.getRemovalReason() != Entity.RemovalReason.CHANGED_DIMENSION; // Folia - region threading
+         boolean flag1 = player instanceof ServerPlayer serverPlayer && serverPlayer.hasDisconnected();
+         if (flag || flag1) {
+             player.drop(stack, false);
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
 index b00ad17852e9890f848fc2124e2287885c2b9c5d..8adf67ce0781a54af76ad54d7df51af48e2ff810 100644
 --- a/net/minecraft/world/item/ItemStack.java


### PR DESCRIPTION
This is a critical issue where crafting slots are kept on death instead of dropping like normal.

This also resolves https://github.com/PaperMC/Folia/issues/393