### PR TITLE
Fix Folia#421

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -16561,7 +16561,7 @@ index c7db74ccc3f8c46e97c24857f297fe5fb5f45e36..ffc93b24e2fee325bf79c648378f7adc
                          if (chicken instanceof Chicken realChicken) {
                              Optional.ofNullable(this.getItem().get(DataComponents.CHICKEN_VARIANT))
 diff --git a/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java b/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
-index 66df6c69a95c5ca6b07294fdb3b13eee6651d22d..7d8c528a76e6a95d27368bc459d654c6ef66dd8f 100644
+index 66df6c69a95c5ca6b07294fdb3b13eee6651d22d..ec7e43d3d412eb6eb39f4009a2ad85e44f0b4cda 100644
 --- a/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
 +++ b/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
 @@ -52,15 +52,11 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
@@ -16685,6 +16685,15 @@ index 66df6c69a95c5ca6b07294fdb3b13eee6651d22d..7d8c528a76e6a95d27368bc459d654c6
              Entity owner = this.getOwner();
              if (owner != null && isAllowedToTeleportOwner(owner, serverLevel)) {
                  Vec3 vec3 = this.oldPosition();
+@@ -172,7 +257,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+             int sectionPosZ = SectionPos.blockToSectionCoord(this.position().z());
+             Entity entity = this.owner != null ? findOwnerIncludingDeadPlayer(serverLevel, this.owner.getUUID()) : null;
+             if (entity instanceof ServerPlayer serverPlayer
+-                && !entity.isAlive()
++                && serverPlayer.getHealth() <= 0.0f // Folia - region threading
+                 && !serverPlayer.wonGame
+                 && serverPlayer.level().getGameRules().get(GameRules.ENDER_PEARLS_VANISH_ON_DEATH)) {
+                 this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
 @@ -196,7 +281,15 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
          }
      }


### PR DESCRIPTION
The issue is caused by the `ThrownEnderpeal#tick` method, where it checks if the `owner` entity is alive, which calls `isRemoved`. In Folia, this is different, and causes ender pearls to vanish when switching dimensions.

The fix proposed is to replace the `!isAlive()` check(which is just `isRemoved()`) with `getHealth() <= 0`, which functions correctly with how it should work.