### PR TITLE
Cleanup watchdog errors

### DIFF
--- a/folia-server/minecraft-patches/features/0008-Add-watchdog-thread.patch
+++ b/folia-server/minecraft-patches/features/0008-Add-watchdog-thread.patch
@@ -8,7 +8,7 @@ of the ticking region should help debug the cause.
 
 diff --git a/io/papermc/paper/threadedregions/FoliaWatchdogThread.java b/io/papermc/paper/threadedregions/FoliaWatchdogThread.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e9ca1a15049b0211d10401cb78e953b93afaf6c7
+index 0000000000000000000000000000000000000000..6017d61bb2266dc1d6a8380d1540e489f7257132
 --- /dev/null
 +++ b/io/papermc/paper/threadedregions/FoliaWatchdogThread.java
 @@ -0,0 +1,104 @@
@@ -84,7 +84,7 @@ index 0000000000000000000000000000000000000000..e9ca1a15049b0211d10401cb78e953b9
 +                }
 +                tick.lastPrint = now;
 +
-+                final double totalElapsedS = (double)(now - tick.start) / 1.0E9;
++                final String totalElapsedS = String.format("%.2f", (now - tick.start) / 1.0E9);
 +
 +                if (tick.handle instanceof TickRegions.ConcreteRegionTickHandle region) {
 +                    LOGGER.error(


### PR DESCRIPTION
More of a QOL fixup, watchdog errors never truncate the actual watchdog print so u get numbers like `5.320823993s` of sorts, which is kinda odd/bad looking, so this is just a 1-liner fixup to truncate to the 2nd decimal