### PR TITLE
Generate crash reports on crash

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -5250,10 +5250,10 @@ index 0000000000000000000000000000000000000000..29ba25f04b8053d16b53ffd42760d2a4
 \ No newline at end of file
 diff --git a/io/papermc/paper/threadedregions/TickRegionScheduler.java b/io/papermc/paper/threadedregions/TickRegionScheduler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0b4f8f57ceaa5e175ac2b13476076e75c4b1383d
+index 0000000000000000000000000000000000000000..d44524c4b6558226a60030578a63da8e952b27e5
 --- /dev/null
 +++ b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-@@ -0,0 +1,562 @@
+@@ -0,0 +1,588 @@
 +package io.papermc.paper.threadedregions;
 +
 +import ca.spottedleaf.concurrentutil.numa.OSNuma;
@@ -5270,12 +5270,17 @@ index 0000000000000000000000000000000000000000..0b4f8f57ceaa5e175ac2b13476076e75
 +import com.mojang.logging.LogUtils;
 +import io.papermc.paper.util.TraceUtil;
 +import it.unimi.dsi.fastutil.ints.Int2IntLinkedOpenHashMap;
++import net.minecraft.CrashReport;
++import net.minecraft.CrashReportCategory;
++import net.minecraft.ReportType;
 +import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ServerLevel;
++import net.minecraft.util.Util;
 +import net.minecraft.world.level.ChunkPos;
 +import org.slf4j.Logger;
 +import java.lang.management.ManagementFactory;
 +import java.lang.management.ThreadMXBean;
++import java.nio.file.Path;
 +import java.util.concurrent.ThreadFactory;
 +import java.util.concurrent.TimeUnit;
 +import java.util.concurrent.atomic.AtomicBoolean;
@@ -5491,6 +5496,15 @@ index 0000000000000000000000000000000000000000..0b4f8f57ceaa5e175ac2b13476076e75
 +    private void uncaughtException(final Thread thread, final Throwable thr) {
 +        LOGGER.error("Uncaught exception in tick thread \"" + thread.getName() + "\"", thr);
 +
++        CrashReport crashReport = CrashReport.forThrowable(thr, "Region Scheduler Crash");
++        MinecraftServer.getServer().fillSystemReport(crashReport.getSystemReport());
++        Path path = MinecraftServer.getServer().getServerDirectory().resolve("crash-reports").resolve("crash-" + Util.getFilenameFormattedDateTime() + "-server.txt");
++        if (crashReport.saveToFile(path, ReportType.CRASH)) {
++            LOGGER.error("This crash report has been saved to: {}", path.toAbsolutePath());
++        } else {
++            LOGGER.error("We were unable to save this crash report to disk.");
++        }
++
 +        // prevent further ticks from occurring
 +        // we CANNOT sync, because WE ARE ON A SCHEDULER THREAD
 +        this.scheduler.halt();
@@ -5500,6 +5514,18 @@ index 0000000000000000000000000000000000000000..0b4f8f57ceaa5e175ac2b13476076e75
 +
 +    private void regionFailed(final RegionScheduleHandle handle, final boolean executingTasks, final Throwable thr) {
 +        // when a region fails, we need to shut down the server gracefully
++
++        CrashReport crashReport = CrashReport.forThrowable(thr, "Region Crash");
++        MinecraftServer.getServer().fillSystemReport(crashReport.getSystemReport());
++        CrashReportCategory crashReportCategory = crashReport.addCategory("Region Context");
++        crashReportCategory.setDetail("Executing Tasks", executingTasks);
++        crashReportCategory.setDetail("RegionScheduleHandle", handle.region == null ? handle == RegionizedServer.getGlobalTickData() ? "Global tick" : "Not available" : handle.region.region);
++        Path path = MinecraftServer.getServer().getServerDirectory().resolve("crash-reports").resolve("crash-" + Util.getFilenameFormattedDateTime() + "-server.txt");
++        if (crashReport.saveToFile(path, ReportType.CRASH)) {
++            LOGGER.error("This crash report has been saved to: {}", path.toAbsolutePath());
++        } else {
++            LOGGER.error("We were unable to save this crash report to disk.");
++        }
 +
 +        // prevent further ticks from occurring
 +        // we CANNOT sync, because WE ARE ON A SCHEDULER THREAD

--- a/folia-server/minecraft-patches/features/0007-Region-profiler.patch
+++ b/folia-server/minecraft-patches/features/0007-Region-profiler.patch
@@ -1059,10 +1059,10 @@ index fdb0bcdca1cd38f55f191d42e422c354af4452b5..24c8581b2fa9c3ef6f6aad64bd4454d6
  
      private boolean saveChunk(final ChunkAccess chunk, final boolean unloading, final Completable<CompoundTag>[] chunkSave) {
 diff --git a/io/papermc/paper/threadedregions/TickRegionScheduler.java b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-index 0b4f8f57ceaa5e175ac2b13476076e75c4b1383d..4eb564fb10a789422570062cbe77e58f66a2cb07 100644
+index d44524c4b6558226a60030578a63da8e952b27e5..2f96adf85d438c355ef127994cb8cb26f38ff03f 100644
 --- a/io/papermc/paper/threadedregions/TickRegionScheduler.java
 +++ b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-@@ -136,8 +136,13 @@ public final class TickRegionScheduler {
+@@ -141,8 +141,13 @@ public final class TickRegionScheduler {
          tickThreadRunner.currentTickingRegion = region;
          if (region != null) {
              tickThreadRunner.currentTickingWorldRegionizedData = region.regioniser.world.worldRegionData.get();
@@ -1076,7 +1076,7 @@ index 0b4f8f57ceaa5e175ac2b13476076e75c4b1383d..4eb564fb10a789422570062cbe77e58f
          }
      }
  
-@@ -192,6 +197,17 @@ public final class TickRegionScheduler {
+@@ -197,6 +202,17 @@ public final class TickRegionScheduler {
          return tickThreadRunner.currentTickingTask;
      }
  
@@ -1094,7 +1094,7 @@ index 0b4f8f57ceaa5e175ac2b13476076e75c4b1383d..4eb564fb10a789422570062cbe77e58f
      /**
       * Schedules the given region
       * @throws IllegalStateException If the region is already scheduled or is ticking
-@@ -264,6 +280,9 @@ public final class TickRegionScheduler {
+@@ -290,6 +306,9 @@ public final class TickRegionScheduler {
          private ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> currentTickingRegion;
          private RegionizedWorldData currentTickingWorldRegionizedData;
          private SchedulableTick currentTickingTask;

--- a/folia-server/minecraft-patches/features/0008-Add-watchdog-thread.patch
+++ b/folia-server/minecraft-patches/features/0008-Add-watchdog-thread.patch
@@ -117,10 +117,10 @@ index 0000000000000000000000000000000000000000..e9ca1a15049b0211d10401cb78e953b9
 +    }
 +}
 diff --git a/io/papermc/paper/threadedregions/TickRegionScheduler.java b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-index 4eb564fb10a789422570062cbe77e58f66a2cb07..439c5a222fcf51c9dc5bfef9cdb23f419fffc28c 100644
+index 2f96adf85d438c355ef127994cb8cb26f38ff03f..945e10a7889ac78b944d783fc8389876f3b9a43f 100644
 --- a/io/papermc/paper/threadedregions/TickRegionScheduler.java
 +++ b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-@@ -42,6 +42,12 @@ public final class TickRegionScheduler {
+@@ -47,6 +47,12 @@ public final class TickRegionScheduler {
  
      public static final int TICK_RATE = 20;
      public static final long TIME_BETWEEN_TICKS = 1_000_000_000L / TICK_RATE; // ns
@@ -133,7 +133,7 @@ index 4eb564fb10a789422570062cbe77e58f66a2cb07..439c5a222fcf51c9dc5bfef9cdb23f41
  
      private final Scheduler scheduler;
  
-@@ -383,6 +389,8 @@ public final class TickRegionScheduler {
+@@ -409,6 +415,8 @@ public final class TickRegionScheduler {
                  this.currentTickingThread = Thread.currentThread();
              }
  
@@ -142,7 +142,7 @@ index 4eb564fb10a789422570062cbe77e58f66a2cb07..439c5a222fcf51c9dc5bfef9cdb23f41
              try {
                  this.runRegionTasks(() -> {
                      return !RegionScheduleHandle.this.cancelled.get() && canContinue.getAsBoolean();
-@@ -392,6 +400,7 @@ public final class TickRegionScheduler {
+@@ -418,6 +426,7 @@ public final class TickRegionScheduler {
                  // don't release region for another tick
                  return false;
              } finally {
@@ -150,7 +150,7 @@ index 4eb564fb10a789422570062cbe77e58f66a2cb07..439c5a222fcf51c9dc5bfef9cdb23f41
                  final long tickEnd = System.nanoTime();
                  final long cpuEnd = MEASURE_CPU_TIME ? THREAD_MX_BEAN.getCurrentThreadCpuTime() : 0L;
  
-@@ -465,6 +474,8 @@ public final class TickRegionScheduler {
+@@ -491,6 +500,8 @@ public final class TickRegionScheduler {
                  this.currentTickingThread = Thread.currentThread();
              }
  
@@ -159,7 +159,7 @@ index 4eb564fb10a789422570062cbe77e58f66a2cb07..439c5a222fcf51c9dc5bfef9cdb23f41
              try {
                  // next start isn't updated until the end of this tick
                  this.tickRegion(tickCount, tickStart, scheduledEnd);
-@@ -473,6 +484,7 @@ public final class TickRegionScheduler {
+@@ -499,6 +510,7 @@ public final class TickRegionScheduler {
                  // regionFailed will schedule a shutdown, so we should avoid letting this region tick further
                  return false;
              } finally {


### PR DESCRIPTION
Folia doesn't generate crash reports when a region crashes or when the tick scheduler has an uncaught exception. This fixes that to generate crash reports when either of those happens