### PR TITLE
Fix spawnRadius 0 ignoring /setworldspawn

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -12326,6 +12326,12 @@ index 06b938013f9dbee4fb3b86979d5a42f28a0ea33e..45921b0c22dc35facd608b1c7644e5b9
 +        BlockPos spawn = world.getLevelData().getRespawnData().pos();
 +        double radius = Math.max(0.0, world.getGameRules().get(GameRules.RESPAWN_RADIUS).doubleValue());
 +
++        // Folia start - fix spawnRadius 0 ignoring setworldspawn
++        if (radius <= 0.0) {
++            return spawn;
++        }
++        // Folia end - fix spawnRadius 0 ignoring setworldspawn
++
 +        double spawnX = (double)spawn.getX() + 0.5;
 +        double spawnZ = (double)spawn.getZ() + 0.5;
 +


### PR DESCRIPTION
## Description
When \spawnRadius\ gamerule is set to 0 and worldspawn is changed via \/setworldspawn\, players respawn at the world border center instead of the configured world spawn point.

## Root cause
In \ServerPlayer.getRandomSpawn()\, when \adius = 0\, \mountX\ and \mountZ\ become 0 (\\< 1.0), causing the code to fall back to \worldBorder.getCenterX()/getCenterZ()\ instead of using the actual spawn position.

## Fix
Added an early return when \adius <= 0.0\ to return the exact world spawn position.

## Related issues
Fixes #401 (regression of #222)