### PR TITLE
Use Minecraft namespace for the teleport command in CommandServerHealth

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -6212,7 +6212,7 @@ index 8424cf9d4617b4732d44cc460d25b04481068989..f34a3cd7290971438ad1217a6f6eca49
  }
 diff --git a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d362c9b19a82b8e87bb52497729a9ff134574b1c
+index 0000000000000000000000000000000000000000..f8b9066d3aba58ea93d9bdab2aea4c1ef10d06ba
 --- /dev/null
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 @@ -0,0 +1,355 @@
@@ -6477,7 +6477,7 @@ index 0000000000000000000000000000000000000000..d362c9b19a82b8e87bb52497729a9ff1
 +                .append(formatRegionStats(region.getData().getRegionStats(), (i + 1) != len))
 +                .build()
 +
-+                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, Payload.string("/minecraft:execute as @s in " + world.getWorld().getKey().toString() + " run tp " + centerBlockX + ".5 " + yLoc + " " + centerBlockZ + ".5")))
++                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, Payload.string("/minecraft:execute as @s in " + world.getWorld().getKey().toString() + " run minecraft:tp " + centerBlockX + ".5 " + yLoc + " " + centerBlockZ + ".5")))
 +                .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text("Click to teleport to " + location, SECONDARY)));
 +
 +            lowestRegionsBuilder.append(line);

--- a/folia-server/minecraft-patches/features/0003-Add-chunk-system-throughput-counters-to-tps.patch
+++ b/folia-server/minecraft-patches/features/0003-Add-chunk-system-throughput-counters-to-tps.patch
@@ -58,7 +58,7 @@ index 96ccb8f657d755b2e58a8dd0cda00ca0df4886b2..fd48134ab73d3096bc86402b4eb393c8
                  chunk = wrappedFull.getWrapped();
              } else {
 diff --git a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
-index d362c9b19a82b8e87bb52497729a9ff134574b1c..aa860cfe9de616f185163fe74e0f4f49bd13a805 100644
+index f8b9066d3aba58ea93d9bdab2aea4c1ef10d06ba..e5ceaf5c01a5b95c8d5c516d8142abb909cd75b6 100644
 --- a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 @@ -170,6 +170,9 @@ public final class CommandServerHealth extends Command {


### PR DESCRIPTION
Plugins can override the default `tp` command. Sometimes, this causes issues. This specifies using the Minecraft `tp` command(like it does for `execute), to prevent issues with plugins.