### PR TITLE
Fix PlayerList advancement/recipe player refreshes, disable restarting/reloading and enabling datapacks with the API

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -13741,7 +13741,7 @@ index e38acabda1d2e49d88b94d46cc51f6602870d6b6..b1b7bfa011bd4b97896cac51cb36e3f4
              parsedDate = defaultValue;
          }
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index baec5d072b8f2d9379dba850b04e881e5267ca6b..9bbb78ccc6c64930b6c52a3cbc73eb9d81167464 100644
+index baec5d072b8f2d9379dba850b04e881e5267ca6b..1f3a086a294bf137e226b78e7def6ab97e0bc36a 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -111,10 +111,10 @@ public abstract class PlayerList {
@@ -14113,6 +14113,47 @@ index baec5d072b8f2d9379dba850b04e881e5267ca6b..9bbb78ccc6c64930b6c52a3cbc73eb9d
              final net.minecraft.world.scores.Scoreboard scoreboard = this.getServer().getLevel(Level.OVERWORLD).getScoreboard();
              final PlayerTeam team = scoreboard.getPlayersTeam(this.collideRuleTeamName);
              if (team != null) scoreboard.removePlayerTeam(team);
+@@ -1270,8 +1355,17 @@ public abstract class PlayerList {
+         //     playerAdvancements.reload(this.server.getAdvancements());
+         // }
+         for (ServerPlayer player : this.players) {
+-            player.getAdvancements().reload(this.server.getAdvancements());
+-            player.getAdvancements().flushDirty(player, false); // CraftBukkit - trigger immediate flush of advancements
++            // Folia start - region threading
++
++            // while normally fine to just leave as-is, since disabled the Minecraft reload command,
++            // the method CraftServer#updateResources can call this, which would kill any player that is
++            // outside the region in context
++
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer entityPlayer) -> {
++                entityPlayer.getAdvancements().reload(this.server.getAdvancements());
++                entityPlayer.getAdvancements().flushDirty(entityPlayer, false); // CraftBukkit - trigger immediate flush of advancements
++            });
++            // Folia end - region threading
+         }
+         // CraftBukkit end
+ 
+@@ -1292,8 +1386,18 @@ public abstract class PlayerList {
+         );
+ 
+         for (ServerPlayer player : this.players) {
+-            player.connection.send(recipes);
+-            player.getRecipeBook().sendInitialRecipeBook(player);
++            // Folia start - region threading
++
++            // while normally fine to just leave as-is, since disabled the Minecraft reload command,
++            // the method CraftServer#updateResources can call this, which would kill any player that is
++            // outside the region in context
++
++            // usage of "schedule" and not "scheduleOrExecute" is intentional
++            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(recipes);
++                entityPlayer.getRecipeBook().sendInitialRecipeBook(entityPlayer);
++            }, null, 1L);
++            // Folia end - region threading
+         }
+     }
+ 
 diff --git a/net/minecraft/server/players/StoredUserList.java b/net/minecraft/server/players/StoredUserList.java
 index eaf8fb8a9cf94d0d16debf90e5ceda3f91c979ef..cf6c71db3dd39094608755998ceff6ca067238f3 100644
 --- a/net/minecraft/server/players/StoredUserList.java

--- a/folia-server/minecraft-patches/features/0002-Max-pending-logins.patch
+++ b/folia-server/minecraft-patches/features/0002-Max-pending-logins.patch
@@ -19,7 +19,7 @@ index 2b641c9180a5890af8fed8bcc8e8ad23d6680c17..95787d6d29ddb8dca78506bb2a115fa6
  
          if (this.state == ServerLoginPacketListenerImpl.State.WAITING_FOR_DUPE_DISCONNECT
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 9bbb78ccc6c64930b6c52a3cbc73eb9d81167464..c36ca30382eb0013644d7230b5585d5123e21cc7 100644
+index 1f3a086a294bf137e226b78e7def6ab97e0bc36a..ef3de3e948c08160b8a66f69e822f63dc307b716 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -149,6 +149,17 @@ public abstract class PlayerList {

--- a/folia-server/minecraft-patches/features/0007-Region-profiler.patch
+++ b/folia-server/minecraft-patches/features/0007-Region-profiler.patch
@@ -1271,7 +1271,7 @@ index 848f4286b1b64f257c8383964b95323d97e4a0de..35ab432bbd59aba80a6eaca1769e6aa8
      }
  
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index c36ca30382eb0013644d7230b5585d5123e21cc7..259eb7574841b1b885093b534440f8a40db4e8e2 100644
+index ef3de3e948c08160b8a66f69e822f63dc307b716..1fd2eaebffc11618847ce5fd6ec3bfe2bb3c44fe 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -1033,6 +1033,7 @@ public abstract class PlayerList {

--- a/folia-server/paper-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/paper-patches/features/0001-Region-Threading-Base.patch
@@ -477,6 +477,22 @@ index c2174c8ae594fe8ec7741ecdbb53e9acc2bbf5b2..0762cfa9748ed6feff74abe060756d7a
                  .thenCompose(Function.identity())
                  .join()
                  .getList(),
+diff --git a/src/main/java/io/papermc/paper/datapack/PaperDatapack.java b/src/main/java/io/papermc/paper/datapack/PaperDatapack.java
+index bbd709529c58d8b690f56c6f523008d7a04bfbcd..61bc9b7f192d7a5715b2772f1fb6cbdbc9d9a030 100644
+--- a/src/main/java/io/papermc/paper/datapack/PaperDatapack.java
++++ b/src/main/java/io/papermc/paper/datapack/PaperDatapack.java
+@@ -28,6 +28,11 @@ public class PaperDatapack extends PaperDiscoveredDatapack implements Datapack {
+ 
+     @Override
+     public void setEnabled(final boolean enabled) {
++        // Folia start - region threading
++        if (true) {
++            throw new UnsupportedOperationException("Unsupported in region threading");
++        }
++        // Folia end - region threading
+         final MinecraftServer server = MinecraftServer.getServer();
+         final List<Pack> enabledPacks = new ArrayList<>(server.getPackRepository().getSelectedPacks());
+         final Pack packToChange = server.getPackRepository().getPack(this.getName());
 diff --git a/src/main/java/io/papermc/paper/entity/PaperSchoolableFish.java b/src/main/java/io/papermc/paper/entity/PaperSchoolableFish.java
 index 661e0c324caca4b4fc6fcb31645a03193ab3dec4..8b5f80419efb0d80445306e8b4b397bed935ab97 100644
 --- a/src/main/java/io/papermc/paper/entity/PaperSchoolableFish.java
@@ -793,7 +809,7 @@ index f659aba1587d70b8d4011e66f40f480ff4deeeb4..532076c7358aa355ce5144075fe6bd79
                  MinecraftServer.LOGGER.warn("Asynchronous " + reason + "!", new IllegalStateException());
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55c2473895 100644
+index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..c047875cf8544d138d43d9458dad8ba8185b37b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -306,7 +306,7 @@ public final class CraftServer implements Server {
@@ -859,7 +875,31 @@ index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55
          CommandSourceStack sourceStack = VanillaCommandWrapper.getListener(rawSender);
  
          String command = StringUtils.normalizeSpace(commandLine.trim());
-@@ -1164,6 +1197,7 @@ public final class CraftServer implements Server {
+@@ -948,6 +981,11 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public void reload() {
++        // Folia start - region threading
++        if (true) {
++            throw new UnsupportedOperationException("Unsupported in region threading");
++        }
++        // Folia end - region threading
+         // Paper start - lifecycle events
+         if (io.papermc.paper.plugin.lifecycle.event.LifecycleEventRunner.INSTANCE.blocksPluginReloading()) {
+             throw new IllegalStateException(org.bukkit.command.defaults.ReloadCommand.RELOADING_DISABLED_MESSAGE);
+@@ -1084,6 +1122,11 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public void reloadData() {
++        // Folia start - region threading
++        if (true) {
++            throw new UnsupportedOperationException("Unsupported in region threading");
++        }
++        // Folia end - region threading
+         ReloadCommand.reload(this.console);
+     }
+ 
+@@ -1164,6 +1207,7 @@ public final class CraftServer implements Server {
  
      @Override
      public World createWorld(WorldCreator creator) {
@@ -867,7 +907,7 @@ index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55
          Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
          //Preconditions.checkState(!this.console.isIteratingOverLevels, "Cannot create a world while worlds are being ticked"); // Paper - Cat - Temp disable. We'll see how this goes.
          Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
-@@ -1321,6 +1355,7 @@ public final class CraftServer implements Server {
+@@ -1321,6 +1365,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean unloadWorld(World world, boolean save) {
@@ -875,7 +915,7 @@ index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55
          //Preconditions.checkState(!this.console.isIteratingOverLevels, "Cannot unload a world while worlds are being ticked"); // Paper - Cat - Temp disable. We'll see how this goes.
          if (world == null) {
              return false;
-@@ -2699,8 +2734,23 @@ public final class CraftServer implements Server {
+@@ -2699,8 +2744,23 @@ public final class CraftServer implements Server {
  
      @Override
      public double getAverageTickTime() {
@@ -901,7 +941,7 @@ index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55
      }
  
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot() {
-@@ -2757,7 +2807,27 @@ public final class CraftServer implements Server {
+@@ -2757,7 +2817,27 @@ public final class CraftServer implements Server {
  
      @Override
      public double[] getTPS() {
@@ -930,7 +970,7 @@ index 716c3b17dc07eb2417dfb0084fe75dbd270f031a..ede5ab54621b44e5bf0d4f6297294e55
      }
  
      @Override
-@@ -2927,7 +2997,7 @@ public final class CraftServer implements Server {
+@@ -2927,7 +3007,7 @@ public final class CraftServer implements Server {
  
      @Override
      public int getCurrentTick() {

--- a/folia-server/paper-patches/features/0006-Add-TPS-From-Region.patch
+++ b/folia-server/paper-patches/features/0006-Add-TPS-From-Region.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add TPS From Region
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ede5ab54621b44e5bf0d4f6297294e55c2473895..3fac32b420ce4ae74166eac43d38c51c1fd513cf 100644
+index c047875cf8544d138d43d9458dad8ba8185b37b9..dadc79b83aaef5b1e063f74905e174170ca30ac4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -3031,4 +3031,69 @@ public final class CraftServer implements Server {
+@@ -3041,4 +3041,69 @@ public final class CraftServer implements Server {
      public void allowPausing(final Plugin plugin, final boolean value) {
          this.console.addPluginAllowingSleep(plugin.getName(), value);
      }


### PR DESCRIPTION
Self explanatory.

Datapacks are unsafe to load during runtime, so that's disabled in `PaperDatapack` now.

`PlayerList#reloadRecipes` and `PlayerList#reloadAdvancementData` are not safe for region threading if called outside of *any* players owning context. There is some Bukkit API that calls these, this fixes the safety issue via proper scheduling to the players in the server.