### PR TITLE
Disable debug subscriptions

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -12254,7 +12254,7 @@ index 59598bfb95c2f8a38efd92685c46a954dc76739d..848f4286b1b64f257c8383964b95323d
      // Paper end - lag compensation
  }
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 3cd4e850f223100b61ac6831a87dd38f3a3bb58f..a96011a9cf68077998f05f251cecdfded488f71d 100644
+index 3cd4e850f223100b61ac6831a87dd38f3a3bb58f..fa81c5e632c118b0ac42962c36f0955ff430fcb0 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -208,7 +208,7 @@ import org.slf4j.Logger;
@@ -12879,6 +12879,15 @@ index 3cd4e850f223100b61ac6831a87dd38f3a3bb58f..a96011a9cf68077998f05f251cecdfde
      }
  
      public Set<ThrownEnderpearl> getEnderPearls() {
+@@ -2962,7 +3461,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     }
+ 
+     public Set<DebugSubscription<?>> debugSubscriptions() {
+-        return !this.server.debugSubscribers().hasRequiredPermissions(this) ? Set.of() : this.requestedDebugSubscriptions;
++        return Set.of(); // Folia - region threading - disable debug subscriptions
+     }
+ 
+     public record RespawnConfig(LevelData.RespawnData respawnData, boolean forced) {
 @@ -3111,7 +3610,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
          this.experienceLevel = this.newLevel;
          this.totalExperience = this.newTotalExp;

--- a/folia-server/minecraft-patches/features/0006-Sync-vehicle-position-to-player-position-on-player-d.patch
+++ b/folia-server/minecraft-patches/features/0006-Sync-vehicle-position-to-player-position-on-player-d.patch
@@ -7,7 +7,7 @@ This allows the player to be re-positioned before logging into
 the world without causing thread checks to trip on Folia.
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index a96011a9cf68077998f05f251cecdfded488f71d..16f49ae6736c475207f31392307e280ec06edbc3 100644
+index fa81c5e632c118b0ac42962c36f0955ff430fcb0..1c8de2154e4240671456d5a7c09a6c5e248bf41e 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -729,8 +729,18 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc


### PR DESCRIPTION
This also fixes:
- https://github.com/PaperMC/Folia/issues/472
- https://github.com/PaperMC/Folia/issues/432

Debug subscriptions are not safe to be ticked in region threading. This resolves this by disabling players from being able to register debug subscribers