### PR TITLE
Fix max player count being offset by 1

### DIFF
--- a/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
+++ b/folia-server/minecraft-patches/features/0001-Region-Threading-Base.patch
@@ -13741,7 +13741,7 @@ index e38acabda1d2e49d88b94d46cc51f6602870d6b6..b1b7bfa011bd4b97896cac51cb36e3f4
              parsedDate = defaultValue;
          }
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index baec5d072b8f2d9379dba850b04e881e5267ca6b..9bbb78ccc6c64930b6c52a3cbc73eb9d81167464 100644
+index baec5d072b8f2d9379dba850b04e881e5267ca6b..484619649553cf15653fa297cc816d25cd9a1eff 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -111,10 +111,10 @@ public abstract class PlayerList {
@@ -13806,7 +13806,7 @@ index baec5d072b8f2d9379dba850b04e881e5267ca6b..9bbb78ccc6c64930b6c52a3cbc73eb9d
 +    private boolean countConnection(Connection conn, int limit) {
 +        synchronized (this.connectionsStateLock) {
 +            int count = this.usersCountedAgainstLimit.size();
-+            if (count >= limit) {
++            if (count > limit) {
 +                return false;
 +            }
 +            this.usersCountedAgainstLimit.add(conn);

--- a/folia-server/minecraft-patches/features/0002-Max-pending-logins.patch
+++ b/folia-server/minecraft-patches/features/0002-Max-pending-logins.patch
@@ -19,7 +19,7 @@ index 2b641c9180a5890af8fed8bcc8e8ad23d6680c17..95787d6d29ddb8dca78506bb2a115fa6
  
          if (this.state == ServerLoginPacketListenerImpl.State.WAITING_FOR_DUPE_DISCONNECT
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 9bbb78ccc6c64930b6c52a3cbc73eb9d81167464..c36ca30382eb0013644d7230b5585d5123e21cc7 100644
+index 484619649553cf15653fa297cc816d25cd9a1eff..6fd5601088622103ae9c205ba4f16cad691be086 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -149,6 +149,17 @@ public abstract class PlayerList {

--- a/folia-server/minecraft-patches/features/0007-Region-profiler.patch
+++ b/folia-server/minecraft-patches/features/0007-Region-profiler.patch
@@ -1271,7 +1271,7 @@ index 848f4286b1b64f257c8383964b95323d97e4a0de..35ab432bbd59aba80a6eaca1769e6aa8
      }
  
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index c36ca30382eb0013644d7230b5585d5123e21cc7..259eb7574841b1b885093b534440f8a40db4e8e2 100644
+index 6fd5601088622103ae9c205ba4f16cad691be086..f7de395586d0cf36b1bac5168e29aa6fdcf89c80 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -1033,6 +1033,7 @@ public abstract class PlayerList {


### PR DESCRIPTION
Folia's logic for counting connections makes it offset from Vanilla by -1 due to the comparison between the limit and the users that count towards the limit being `>=`, instead of `>`. While honestly minor, an issue nonetheless and is worth fixing perhaps.