### PR TITLE
Flood inspired fluid optimization for load reduction while flooding happens

### DIFF
--- a/folia-server/minecraft-patches/features/0012-Add-process-wide-fluid-tick-budget.patch
+++ b/folia-server/minecraft-patches/features/0012-Add-process-wide-fluid-tick-budget.patch
@@ -1,0 +1,376 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mattia <mattiapearl@gmail.com>
+Date: Mon, 17 Aug 2026 17:41:57 +0200
+Subject: [PATCH] Add process-wide fluid tick budget
+
+Folia applies the existing fluid tick limit independently to each
+ticking region, so aggregate work can grow with the number of active
+regions. Add an opt-in process-wide allocation with regional floors,
+equal sharing, bounded age weighting, rotating tie order, configuration
+validation, and profiler counters. Scheduled work is delayed rather
+than discarded.
+
+diff --git a/ca/spottedleaf/leafprofiler/LProfilerRegistry.java b/ca/spottedleaf/leafprofiler/LProfilerRegistry.java
+index a000e8a944ce1c4648e783d45dbd121a977acc43..21f503eff43df54417f084a40d55d1216484c111 100644
+--- a/ca/spottedleaf/leafprofiler/LProfilerRegistry.java
++++ b/ca/spottedleaf/leafprofiler/LProfilerRegistry.java
+@@ -19,6 +19,8 @@ public final class LProfilerRegistry {
+     public static final int CHUNK_SAVE = GLOBAL_REGISTRY.createType(ProfileType.TIMER, "Chunk Save");
+     public static final int BLOCK_TICK = GLOBAL_REGISTRY.createType(ProfileType.TIMER, "Block Tick");
+     public static final int FLUID_TICK = GLOBAL_REGISTRY.createType(ProfileType.TIMER, "Fluid Tick");
++    public static final int FLUID_TICK_BUDGET_GRANTED = GLOBAL_REGISTRY.createType(ProfileType.COUNTER, "Fluid Tick Budget Granted");
++    public static final int FLUID_TICK_BUDGET_USED = GLOBAL_REGISTRY.createType(ProfileType.COUNTER, "Fluid Tick Budget Used");
+     public static final int BLOCK_OR_FLUID_TICK_COUNT = GLOBAL_REGISTRY.createType(ProfileType.COUNTER, "Block/Fluid Tick Count");
+     public static final int RAIDS_TICK = GLOBAL_REGISTRY.createType(ProfileType.TIMER, "Raids Tick");
+     public static final int CHUNK_PROVIDER_TICK = GLOBAL_REGISTRY.createType(ProfileType.TIMER, "Chunk Source Tick");
+diff --git a/io/papermc/paper/threadedregions/FluidTickBudget.java b/io/papermc/paper/threadedregions/FluidTickBudget.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9eefdfc8f2773d78ced9f38420433bb85f76eab4
+--- /dev/null
++++ b/io/papermc/paper/threadedregions/FluidTickBudget.java
+@@ -0,0 +1,280 @@
++package io.papermc.paper.threadedregions;
++
++import io.papermc.paper.configuration.GlobalConfiguration;
++import java.util.ArrayList;
++import java.util.Collections;
++import java.util.Comparator;
++import java.util.List;
++import java.util.concurrent.ConcurrentHashMap;
++import java.util.concurrent.atomic.AtomicLong;
++
++/**
++ * Shares a bounded amount of fluid tick execution between Folia regions.
++ *
++ * <p>Allocations use the active-region snapshot from the current or preceding
++ * 50 ms epoch. This makes grant order independent of the order in which region
++ * threads arrive, at the cost of intentionally conservative grants when
++ * regions become active or inactive.</p>
++ */
++public final class FluidTickBudget {
++    private static final long EPOCH_NANOS = 50_000_000L;
++    private static final Object ALLOCATION_LOCK = new Object();
++    private static final AtomicLong NEXT_ID = new AtomicLong();
++    private static final ConcurrentHashMap<RegionizedWorldData, RegionState> STATES = new ConcurrentHashMap<>();
++    private static volatile long allocationEpoch = Long.MIN_VALUE;
++
++    private FluidTickBudget() {
++    }
++
++    public static boolean enabled() {
++        final GlobalConfiguration.ThreadedRegions.FluidTickBudget config = configuration();
++        return config != null && config.enabled;
++    }
++
++    public static int acquire(
++        final RegionizedWorldData region,
++        final boolean hasRunnableTicks,
++        final long oldestRunnableTick,
++        final long currentTick,
++        final int localMaximum
++    ) {
++        final GlobalConfiguration.ThreadedRegions.FluidTickBudget config = configuration();
++        if (config == null || !config.enabled) {
++            return localMaximum;
++        }
++        final Settings settings = settings(config);
++
++        final long epoch = System.nanoTime() / EPOCH_NANOS;
++        final RegionState state = STATES.computeIfAbsent(region, ignored -> new RegionState(NEXT_ID.getAndIncrement()));
++        final boolean due = hasRunnableTicks && oldestRunnableTick <= currentTick;
++        state.overdueTicks = due ? saturatedAge(currentTick, oldestRunnableTick) : 0L;
++        state.demand = due ? localMaximum : 0;
++        // Publish this last so allocation sees the demand and age for this observation.
++        state.seenEpoch = epoch;
++
++        allocateEpoch(epoch, settings);
++        if (localMaximum <= 0) {
++            return 0;
++        }
++        synchronized (state) {
++            if (state.allocatedEpoch != epoch || state.claimedEpoch == epoch) {
++                return 0;
++            }
++            state.claimedEpoch = epoch;
++            final int grant = Math.min(localMaximum, state.allocation);
++            TickRegionScheduler.getProfiler().addCounter(
++                ca.spottedleaf.leafprofiler.LProfilerRegistry.FLUID_TICK_BUDGET_GRANTED,
++                grant
++            );
++            return grant;
++        }
++    }
++
++    public static void recordUsage(final RegionizedWorldData region, final int executed) {
++        if (executed <= 0 || !enabled() || STATES.get(region) == null) {
++            return;
++        }
++        TickRegionScheduler.getProfiler().addCounter(
++            ca.spottedleaf.leafprofiler.LProfilerRegistry.FLUID_TICK_BUDGET_USED,
++            executed
++        );
++    }
++
++    private static GlobalConfiguration.ThreadedRegions.FluidTickBudget configuration() {
++        final GlobalConfiguration.ThreadedRegions threadedRegions = GlobalConfiguration.get().threadedRegions;
++        return threadedRegions == null ? null : threadedRegions.fluidTickBudget;
++    }
++
++    private static Settings settings(final GlobalConfiguration.ThreadedRegions.FluidTickBudget config) {
++        return new Settings(
++            config.enabled,
++            config.processMaximum,
++            config.regionMinimum,
++            config.targetAgeTicks,
++            config.maxAgeWeight,
++            config.fairSharePercent
++        );
++    }
++
++    private static void allocateEpoch(final long epoch, final Settings settings) {
++        if (allocationEpoch >= epoch) {
++            return;
++        }
++        synchronized (ALLOCATION_LOCK) {
++            if (allocationEpoch >= epoch) {
++                return;
++            }
++            allocationEpoch = epoch;
++            STATES.entrySet().removeIf(entry -> entry.getValue().seenEpoch < epoch - 2L);
++
++            final List<RegionState> activeStates = new ArrayList<>();
++            final List<Demand> demands = new ArrayList<>();
++            for (final RegionState state : STATES.values()) {
++                if (state.seenEpoch >= epoch - 1L && state.demand > 0) {
++                    activeStates.add(state);
++                    demands.add(new Demand(state.id, state.demand, state.overdueTicks));
++                }
++            }
++
++            final int[] allocations = allocate(settings, epoch, demands);
++            for (int index = 0; index < activeStates.size(); ++index) {
++                final RegionState state = activeStates.get(index);
++                synchronized (state) {
++                    state.allocation = allocations[index];
++                    state.allocatedEpoch = epoch;
++                }
++            }
++        }
++    }
++
++    static int[] allocate(final Settings settings, final long epoch, final List<Demand> demands) {
++        final int[] result = new int[demands.size()];
++        if (!settings.enabled() || settings.processMaximum() <= 0 || demands.isEmpty()) {
++            return result;
++        }
++
++        final List<MutableDemand> active = new ArrayList<>(demands.size());
++        for (int index = 0; index < demands.size(); ++index) {
++            final Demand demand = demands.get(index);
++            if (demand.ticks() > 0) {
++                active.add(new MutableDemand(index, demand));
++            }
++        }
++        active.sort(Comparator.comparingLong(target -> target.demand.id()));
++        if (!active.isEmpty()) {
++            Collections.rotate(active, -(int)Math.floorMod(epoch, active.size()));
++        }
++
++        int remaining = settings.processMaximum();
++        if (!active.isEmpty()) {
++            final int floor = Math.min(settings.regionMinimum(), remaining / active.size());
++            for (final MutableDemand target : active) {
++                final int granted = Math.min(target.demand.ticks(), floor);
++                target.allocation = granted;
++                remaining -= granted;
++            }
++
++            int fairRemaining = (int)((long)remaining * settings.fairSharePercent() / 100L);
++            final int fairBudget = fairRemaining;
++            while (fairRemaining > 0) {
++                int unsatisfied = 0;
++                for (final MutableDemand target : active) {
++                    if (target.allocation < target.demand.ticks()) {
++                        ++unsatisfied;
++                    }
++                }
++                if (unsatisfied == 0) {
++                    break;
++                }
++                final int share = Math.max(1, fairRemaining / unsatisfied);
++                boolean progressed = false;
++                for (final MutableDemand target : active) {
++                    if (target.allocation >= target.demand.ticks() || fairRemaining == 0) {
++                        continue;
++                    }
++                    final int granted = Math.min(
++                        fairRemaining,
++                        Math.min(target.demand.ticks() - target.allocation, share)
++                    );
++                    target.allocation += granted;
++                    fairRemaining -= granted;
++                    remaining -= granted;
++                    progressed |= granted != 0;
++                }
++                if (!progressed) {
++                    break;
++                }
++            }
++
++            // Do not give both equal-pool and reserve rounding remainders to the same tie order.
++            final List<MutableDemand> ageOrder = new ArrayList<>(active);
++            if (!ageOrder.isEmpty()) {
++                Collections.rotate(ageOrder, -Math.floorMod(fairBudget, ageOrder.size()));
++            }
++            while (remaining > 0) {
++                long totalWeight = 0L;
++                for (final MutableDemand target : ageOrder) {
++                    if (target.allocation < target.demand.ticks()) {
++                        totalWeight += weight(settings, target.demand.overdueTicks());
++                    }
++                }
++                if (totalWeight == 0L) {
++                    break;
++                }
++                final int roundBudget = remaining;
++                boolean progressed = false;
++                for (final MutableDemand target : ageOrder) {
++                    if (target.allocation >= target.demand.ticks() || remaining == 0) {
++                        continue;
++                    }
++                    final int share = Math.max(
++                        1,
++                        (int)((long)roundBudget * weight(settings, target.demand.overdueTicks()) / totalWeight)
++                    );
++                    final int granted = Math.min(
++                        remaining,
++                        Math.min(target.demand.ticks() - target.allocation, share)
++                    );
++                    target.allocation += granted;
++                    remaining -= granted;
++                    progressed |= granted != 0;
++                }
++                if (!progressed) {
++                    break;
++                }
++            }
++        }
++
++        for (final MutableDemand target : active) {
++            result[target.originalIndex] = target.allocation;
++        }
++        return result;
++    }
++
++    private static int weight(final Settings settings, final long overdueTicks) {
++        return 1 + (int)Math.min(settings.maxAgeWeight() - 1L, overdueTicks / settings.targetAgeTicks());
++    }
++
++    private static long saturatedAge(final long currentTick, final long oldestRunnableTick) {
++        final long age = currentTick - oldestRunnableTick;
++        return age < 0L ? Long.MAX_VALUE : age;
++    }
++
++    static record Settings(
++        boolean enabled,
++        int processMaximum,
++        int regionMinimum,
++        int targetAgeTicks,
++        int maxAgeWeight,
++        int fairSharePercent
++    ) {
++    }
++
++    static record Demand(long id, int ticks, long overdueTicks) {
++    }
++
++    private static final class MutableDemand {
++        private final int originalIndex;
++        private final Demand demand;
++        private int allocation;
++
++        private MutableDemand(final int originalIndex, final Demand demand) {
++            this.originalIndex = originalIndex;
++            this.demand = demand;
++        }
++    }
++
++    private static final class RegionState {
++        private final long id;
++        private volatile long seenEpoch = Long.MIN_VALUE;
++        private volatile int demand;
++        private volatile long overdueTicks;
++        private volatile long allocatedEpoch = Long.MIN_VALUE;
++        private volatile long claimedEpoch = Long.MIN_VALUE;
++        private int allocation;
++
++        private RegionState(final long id) {
++            this.id = id;
++        }
++    }
++}
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index 35ab432bbd59aba80a6eaca1769e6aa82c8a7e46..025b03bf51fc11f760fdda9d8d2e14fdaf03af05 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -857,7 +857,19 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+             } finally { foliaProfiler.stopTimer(ca.spottedleaf.leafprofiler.LProfilerRegistry.BLOCK_TICK); } // Folia - profiler
+             profiler.popPush("fluidTicks");
+             foliaProfiler.startTimer(ca.spottedleaf.leafprofiler.LProfilerRegistry.FLUID_TICK); try { // Folia - profiler
+-            regionizedWorldData.getFluidLevelTicks().tick(tick, paperConfig().environment.maxFluidTicks, this::tickFluid); // Paper - configurable max fluid ticks // Folia - region threading
++            final LevelTicks<Fluid> fluidTicks = regionizedWorldData.getFluidLevelTicks();
++            if (io.papermc.paper.threadedregions.FluidTickBudget.enabled()) {
++                final int executedFluidTicks = fluidTicks.tickBudgeted(
++                    tick,
++                    (hasRunnableTicks, oldestRunnableTick) -> io.papermc.paper.threadedregions.FluidTickBudget.acquire(
++                        regionizedWorldData, hasRunnableTicks, oldestRunnableTick, tick, paperConfig().environment.maxFluidTicks
++                    ),
++                    this::tickFluid
++                );
++                io.papermc.paper.threadedregions.FluidTickBudget.recordUsage(regionizedWorldData, executedFluidTicks);
++            } else {
++                fluidTicks.tick(tick, paperConfig().environment.maxFluidTicks, this::tickFluid);
++            } // Paper - configurable max fluid ticks // Folia - region threading
+             } finally { foliaProfiler.stopTimer(ca.spottedleaf.leafprofiler.LProfilerRegistry.FLUID_TICK); } // Folia - profiler
+             profiler.pop();
+         }
+diff --git a/net/minecraft/world/ticks/LevelTicks.java b/net/minecraft/world/ticks/LevelTicks.java
+index 52a7da01ce84b93a4444a002effa261d20e1a707..ef8aa58d735f210e38bb6f7dc3f3f1a5c49b5f5d 100644
+--- a/net/minecraft/world/ticks/LevelTicks.java
++++ b/net/minecraft/world/ticks/LevelTicks.java
+@@ -165,6 +165,35 @@ public class LevelTicks<T> implements LevelTickAccess<T> {
+         this.rescheduleLeftoverContainers();
+     }
+ 
++    // Folia start - process-wide fluid tick budget
++    public int tickBudgeted(final long currentTick, final TickBudget tickBudget, final BiConsumer<BlockPos, T> output) {
++        ProfilerFiller profiler = Profiler.get();
++        profiler.push("collect");
++        this.sortContainersToTick(currentTick);
++        profiler.incrementCounter("containersToTick", this.containersToTick.size());
++        final LevelChunkTicks<T> oldestContainer = this.containersToTick.peek();
++        final int maxTicksToProcess = Math.max(
++            0,
++            tickBudget.apply(oldestContainer != null, oldestContainer == null ? 0L : oldestContainer.peek().triggerTick())
++        );
++        this.drainContainers(currentTick, maxTicksToProcess);
++        this.rescheduleLeftoverContainers();
++        profiler.popPush("run");
++        final int executed = this.toRunThisTick.size();
++        profiler.incrementCounter("ticksToRun", executed);
++        this.runCollectedTicks(output);
++        profiler.popPush("cleanup");
++        this.cleanupAfterTick();
++        profiler.pop();
++        return executed;
++    }
++
++    @FunctionalInterface
++    public interface TickBudget {
++        int apply(boolean hasRunnableTicks, long oldestRunnableTick);
++    }
++    // Folia end - process-wide fluid tick budget
++
+     private void sortContainersToTick(final long currentTick) {
+         ObjectIterator<Entry> it = Long2LongMaps.fastIterator(this.nextTickForContainer);
+ 

--- a/folia-server/paper-patches/features/0007-Add-process-wide-fluid-tick-budget.patch
+++ b/folia-server/paper-patches/features/0007-Add-process-wide-fluid-tick-budget.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mattia <mattiapearl@gmail.com>
+Date: Mon, 17 Aug 2026 17:41:57 +0200
+Subject: [PATCH] Add process-wide fluid tick budget
+
+Folia applies the existing fluid tick limit independently to each
+ticking region, so aggregate work can grow with the number of active
+regions. Add an opt-in process-wide allocation with regional floors,
+equal sharing, bounded age weighting, rotating tie order, configuration
+validation, and profiler counters. Scheduled work is delayed rather
+than discarded.
+
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index c52d41fd078b7f7aeb3633a9c196bbaba299af0f..d08f5dd2cf3f4dc9322faaea2eb9194277f84c4e 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -404,6 +404,28 @@ public class GlobalConfiguration extends ConfigurationPart {
+         public int threads = -1;
+         public int gridExponent = 4;
+         public io.papermc.paper.threadedregions.TickRegionScheduler.SchedulerType scheduler = io.papermc.paper.threadedregions.TickRegionScheduler.SchedulerType.EDF;
++        public FluidTickBudget fluidTickBudget;
++
++        public class FluidTickBudget extends ConfigurationPart {
++            @Comment("Limits fluid ticks across all ticking regions. Work is delayed, not discarded.")
++            public boolean enabled = false;
++            @Comment("Maximum fluid ticks granted process-wide during each 50 ms wall-clock interval.")
++            @Constraints.Min(1)
++            public int processMaximum = 2_000;
++            @Comment("Minimum grant attempted for every active region before distributing the remainder.")
++            @Constraints.Min(0)
++            public int regionMinimum = 50;
++            @Comment("Queue age, in ticks, represented by each additional age weight.")
++            @Constraints.Min(1)
++            public int targetAgeTicks = 20;
++            @Comment("Maximum weight assigned to an old runnable queue.")
++            @Constraints.Min(1)
++            public int maxAgeWeight = 8;
++            @Comment("Percentage of the remainder distributed equally before age weighting.")
++            @Constraints.Min(0)
++            @Constraints.Max(100)
++            public int fairSharePercent = 75;
++        }
+ 
+         @PostProcess
+         public void postProcess() {

--- a/folia-server/src/test/java/io/papermc/paper/threadedregions/FluidTickBudgetTest.java
+++ b/folia-server/src/test/java/io/papermc/paper/threadedregions/FluidTickBudgetTest.java
@@ -1,0 +1,167 @@
+package io.papermc.paper.threadedregions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("Normal")
+class FluidTickBudgetTest {
+    @Test
+    void disabledBudgetAllocatesNothing() {
+        final int[] allocations = FluidTickBudget.allocate(
+            settings(false, 2_000, 50, 75),
+            0L,
+            demands(1_000, 1_000)
+        );
+
+        assertArrayEquals(new int[] {0, 0}, allocations);
+    }
+
+    @Test
+    void allocationNeverExceedsProcessOrRegionalDemand() {
+        final List<FluidTickBudget.Demand> demands = List.of(
+            new FluidTickBudget.Demand(0L, 10, 0L),
+            new FluidTickBudget.Demand(1L, 1_000, 20L),
+            new FluidTickBudget.Demand(2L, 5_000, Long.MAX_VALUE)
+        );
+        final int[] allocations = FluidTickBudget.allocate(settings(true, 2_000, 50, 75), 0L, demands);
+
+        assertTrue(sum(allocations) <= 2_000);
+        for (int index = 0; index < allocations.length; ++index) {
+            assertTrue(allocations[index] >= 0);
+            assertTrue(allocations[index] <= demands.get(index).ticks());
+        }
+    }
+
+    @Test
+    void equallyLoadedRegionsReceiveEqualShares() {
+        final int[] allocations = FluidTickBudget.allocate(
+            settings(true, 2_000, 50, 75),
+            0L,
+            demands(65_536, 65_536, 65_536, 65_536)
+        );
+
+        assertEquals(2_000, sum(allocations));
+        final int minimum = Math.min(Math.min(allocations[0], allocations[1]), Math.min(allocations[2], allocations[3]));
+        final int maximum = Math.max(Math.max(allocations[0], allocations[1]), Math.max(allocations[2], allocations[3]));
+        assertTrue(maximum - minimum <= 1);
+    }
+
+    @Test
+    void ageOnlyWeightsTheReservedRemainder() {
+        final List<FluidTickBudget.Demand> demands = List.of(
+            new FluidTickBudget.Demand(0L, 10_000, 0L),
+            new FluidTickBudget.Demand(1L, 10_000, 200L)
+        );
+        final int[] allocations = FluidTickBudget.allocate(settings(true, 2_000, 50, 75), 0L, demands);
+
+        assertEquals(2_000, sum(allocations));
+        assertTrue(allocations[1] > allocations[0]);
+        // The 75% fair pool plus the floor prevents age from monopolising the epoch.
+        assertTrue(allocations[0] >= 800);
+    }
+
+    @Test
+    void unusedDemandIsNotInvented() {
+        final int[] allocations = FluidTickBudget.allocate(
+            settings(true, 2_000, 50, 75),
+            0L,
+            demands(7, 11, 13)
+        );
+
+        assertArrayEquals(new int[] {7, 11, 13}, allocations);
+    }
+
+    @Test
+    void rotatingTieOrderIsFairAcrossEpochs() {
+        final int[] totals = new int[3];
+        for (long epoch = 0L; epoch < 3L; ++epoch) {
+            final int[] allocations = FluidTickBudget.allocate(
+                settings(true, 2, 0, 100),
+                epoch,
+                demands(10, 10, 10)
+            );
+            for (int index = 0; index < totals.length; ++index) {
+                totals[index] += allocations[index];
+            }
+        }
+
+        assertArrayEquals(new int[] {2, 2, 2}, totals);
+    }
+
+    @Test
+    void ageWeightSaturatesAtConfiguredMaximum() {
+        final List<FluidTickBudget.Demand> demands = List.of(
+            new FluidTickBudget.Demand(0L, 10_000, 20L),
+            new FluidTickBudget.Demand(1L, 10_000, Long.MAX_VALUE)
+        );
+        final int[] allocations = FluidTickBudget.allocate(settings(true, 2_000, 0, 0), 0L, demands);
+
+        assertEquals(2_000, sum(allocations));
+        assertTrue(allocations[1] > allocations[0]);
+    }
+
+    @Test
+    void randomizedAllocationsRespectAllBounds() {
+        final Random random = new Random(0x5EEDBEEFL);
+        for (int iteration = 0; iteration < 10_000; ++iteration) {
+            final int processMaximum = random.nextInt(1, 20_001);
+            final FluidTickBudget.Settings settings = new FluidTickBudget.Settings(
+                true,
+                processMaximum,
+                random.nextInt(0, 501),
+                random.nextInt(1, 101),
+                random.nextInt(1, 17),
+                random.nextInt(0, 101)
+            );
+            final int regionCount = random.nextInt(0, 65);
+            final List<FluidTickBudget.Demand> demands = new ArrayList<>(regionCount);
+            long totalDemand = 0L;
+            for (int region = 0; region < regionCount; ++region) {
+                final int demand = random.nextInt(0, 65_537);
+                final long age = random.nextBoolean() ? random.nextLong(0L, 10_001L) : Long.MAX_VALUE;
+                demands.add(new FluidTickBudget.Demand(region, demand, age));
+                totalDemand += demand;
+            }
+
+            final int[] allocations = FluidTickBudget.allocate(settings, random.nextLong(), demands);
+            assertEquals(regionCount, allocations.length);
+            assertEquals(Math.min((long)processMaximum, totalDemand), sum(allocations));
+            for (int region = 0; region < regionCount; ++region) {
+                assertTrue(allocations[region] >= 0);
+                assertTrue(allocations[region] <= demands.get(region).ticks());
+            }
+        }
+    }
+
+    private static FluidTickBudget.Settings settings(
+        final boolean enabled,
+        final int processMaximum,
+        final int regionMinimum,
+        final int fairSharePercent
+    ) {
+        return new FluidTickBudget.Settings(enabled, processMaximum, regionMinimum, 20, 8, fairSharePercent);
+    }
+
+    private static List<FluidTickBudget.Demand> demands(final int... ticks) {
+        final java.util.ArrayList<FluidTickBudget.Demand> result = new java.util.ArrayList<>(ticks.length);
+        for (int index = 0; index < ticks.length; ++index) {
+            result.add(new FluidTickBudget.Demand(index, ticks[index], 0L));
+        }
+        return result;
+    }
+
+    private static int sum(final int[] values) {
+        int result = 0;
+        for (final int value : values) {
+            result += value;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
With the inspiration of the flooding of DonutSMP I figured that Folia’s regional fluid limits multiply across separated floods. What we can do is place an optional fair ceiling on total process execution and schedule to delay rather than fully deleting it. Protects all resources impacted by flooding (CPU, allocation, heap and network loads).

## Benchmarks

- Executor: Pi AI agent
- Direction and code review: contributor
- Runtime: Java 25, eight Folia region threads, 4 GiB heap, seed `8675309`, fresh worlds
- Instrumentation: JFR, Folia regional profiler, queue counts, heap, storage records, and protocol clients

### Public Folia scaling baseline

Fifteen-second one-flood versus four-flood runs:

| Metric | One flood | Four floods | Scaling |
|---|---:|---:|---:|
| Executed fluid ticks | 518,646 | 2,076,950 | 4.005× |
| Allocation estimate | 42.2 MB/s | 169.7 MB/s | 4.020× |

Region files, records, and stored bytes also scaled approximately fourfold while regions remained near 20 TPS.

### Five stock/five controller four-region trials

These paired results measured the v7 precursor allocator at a process maximum of 2,000 fluid ticks per 50 ms:

| Metric | Stock median | Controller median | Change |
|---|---:|---:|---:|
| Executed fluid ticks | 1,378,881 | 393,225 | −71.48% |
| Fluid phase | 3,363 ms | 1,041 ms | −69.05% |
| Regional average MSPT | 5.350 | 2.110 | −60.56% |
| Allocation estimate | 172.60 MB/s | 57.04 MB/s | −66.95% |
| Used heap | 2.184 GB | 1.026 GB | −53.00% |
| Queued ticks | 35,068 | 35,195 | +0.36% |
| Target-region storage | 19,472,384 B | 19,472,384 B | 0% |

### Final implementation smoke

With `process-maximum: 2000` per 50 ms over four regions:

- 804 profiled regional ticks
- 398,500 fluid ticks granted
- 392,746 fluid ticks consumed
- 98.56% grant utilization
- Per-region consumption: 97,555–98,713
- Total execution remained within the expected approximately 400,000-tick ten-second envelope.

### Non-binding controller test

Five stock/candidate pairs with a 65,536-per-50-ms process maximum:

- Executed-work difference: approximately +0.003%.
- No controller overhead was detected.
- The incidental fluid-time difference was not treated as evidence of a speedup.

### Real-client network campaign

Four floods with four protocol clients:

| Metric | Stock | Controller | Change |
|---|---:|---:|---:|
| TCP bytes | 1,533,149 | 744,534 | −51.44% |
| Decoded bytes | 3,494,911 | 1,427,938 | −59.14% |
| Multi-block bytes | 2,198,993 | 707,232 | −67.84% |
| Light-update bytes | 1,272,421 | 709,230 | −44.26% |
| Packet count | 7,982 | 6,869 | −13.95% |

The protocol bot advertised 26.2 protocol 776 using available 26.1 packet definitions. TCP counters are exact; parser-level packet classifications carry that limitation.

## AI assistance disclosure

- AI materially assisted—not merely autocomplete.
- Primary model: `gpt-5.6-sol`, maximum reasoning.
- Seven `gpt-5.6-terra:medium` research agents.
- Two `gpt-5.6-luna:low` read-only scouts.
- Assistance covered research, code inspection, implementation, tests, benchmark harnesses, analysis, and issue/PR searches.
- No independent AI reviewer was used.
- The passive review ledger only recorded prompts/responses; it did not perform review.
- I reviewed all the code, understand it, and accept responsibility for the contribution.
