### PR TITLE
Fix ender dragon part registration across regions

### DIFF
--- a/folia-server/minecraft-patches/features/0012-Sync-ender-dragon-parts-before-registration.patch
+++ b/folia-server/minecraft-patches/features/0012-Sync-ender-dragon-parts-before-registration.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Akram Soqrati <169198624+itarqos5@users.noreply.github.com>
+Date: Thu, 27 Aug 2026 01:20:00 +0000
+Subject: [PATCH] Sync ender dragon parts before registration
+
+
+diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java
+index aa53138b3670a8337b639472a6ab5ce46702ff76..4b77802e817825259fe55e06acb7b1af1c140bf1 100644
+--- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java
++++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java
+@@ -86,6 +86,11 @@ public final class ServerEntityLookup extends EntityLookup {
+ 
+     @Override
+     protected void addEntityCallback(final Entity entity) {
++        // Folia start - keep multipart entities in the owning region before registration
++        if (entity instanceof net.minecraft.world.entity.boss.enderdragon.EnderDragon dragon) {
++            dragon.syncPartPositions();
++        }
++        // Folia end - keep multipart entities in the owning region before registration
+         this.world.getCurrentWorldData().addEntity(entity); // Folia - region threading
+         if (entity instanceof ServerPlayer player) {
+             ((ChunkSystemServerLevel)this.serverWorld).moonrise$getNearbyPlayers().addPlayer(player);
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index 5e5036ccc94160f45a0215a9191d5b980f87304c..068470874f280917601981871b4b57dc61bb0841 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -4463,6 +4463,11 @@ public abstract class Entity
+         Entity copy = this.getType().create(destination, EntitySpawnReason.DIMENSION_TRAVEL);
+         copy.restoreFrom(this);
+         copy.transform(pos, yaw, pitch, velocity);
++        // Folia start - keep multipart entities in the owning region after transform
++        if (copy instanceof net.minecraft.world.entity.boss.enderdragon.EnderDragon dragon) {
++            dragon.syncPartPositions();
++        }
++        // Folia end - keep multipart entities in the owning region after transform
+         // vanilla code used to call remove _after_ copying, and some stuff is required to be after copy - so add hook here
+         // for example, clearing of inventory after switching dimensions
+         this.postRemoveAfterChangingDimensions();
+diff --git a/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+index ab921ab4b4cc860abd77744f2bd201013e136e51..393fe38ecb9937861f0fa40122f5c46f97301f55 100644
+--- a/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
++++ b/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
+@@ -1011,4 +1011,12 @@ public class EnderDragon extends Mob implements Enemy {
+         return 500;
+     }
+     // Paper end - init expToDrop for already dying spawned dragon
++
++    // Folia start - keep multipart entities in the owning region before registration
++    public void syncPartPositions() {
++        for (EnderDragonPart part : this.getSubEntities()) {
++            this.tickPart(part, 0.0, 0.0, 0.0);
++        }
++    }
++    // Folia end - keep multipart entities in the owning region before registration
+ }

--- a/folia-server/paper-patches/features/0007-Test-ender-dragon-part-position-sync.patch
+++ b/folia-server/paper-patches/features/0007-Test-ender-dragon-part-position-sync.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Akram Soqrati <169198624+itarqos5@users.noreply.github.com>
+Date: Thu, 27 Aug 2026 01:20:00 +0000
+Subject: [PATCH] Test ender dragon part position sync
+
+
+diff --git a/src/test/java/io/papermc/paper/threadedregions/EnderDragonPartPositionTest.java b/src/test/java/io/papermc/paper/threadedregions/EnderDragonPartPositionTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..67eea51b3e8989f1b2f2950bd483ab287fe34aac
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/threadedregions/EnderDragonPartPositionTest.java
+@@ -0,0 +1,32 @@
++package io.papermc.paper.threadedregions;
++
++import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
++import net.minecraft.world.entity.boss.enderdragon.EnderDragonPart;
++import org.bukkit.support.environment.Normal;
++import org.junit.jupiter.api.Test;
++
++import static org.mockito.Mockito.doCallRealMethod;
++import static org.mockito.Mockito.mock;
++import static org.mockito.Mockito.verify;
++import static org.mockito.Mockito.when;
++
++@Normal
++class EnderDragonPartPositionTest {
++
++    @Test
++    void syncsPartsToDragonPositionBeforeRegistration() {
++        final EnderDragon dragon = mock(EnderDragon.class);
++        final EnderDragonPart[] parts = {mock(EnderDragonPart.class), mock(EnderDragonPart.class)};
++        when(dragon.getSubEntities()).thenReturn(parts);
++        when(dragon.getX()).thenReturn(4096.5);
++        when(dragon.getY()).thenReturn(80.0);
++        when(dragon.getZ()).thenReturn(-4096.5);
++        doCallRealMethod().when(dragon).syncPartPositions();
++
++        dragon.syncPartPositions();
++
++        for (final EnderDragonPart part : parts) {
++            verify(part).setPos(4096.5, 80.0, -4096.5);
++        }
++    }
++}


### PR DESCRIPTION
Synchronize dragon parts with their parent before entity registration and after cross-dimension transforms so multipart tracking never sees stale coordinates from chunk 0,0.

Add regression coverage for the synchronization contract.

Fixes PaperMC/Folia#427